### PR TITLE
Longer test app

### DIFF
--- a/test_app_manager/README.md
+++ b/test_app_manager/README.md
@@ -33,4 +33,4 @@ In the app, the following plugins are executed according to `test_app.app`.
 - video\_recorder\_plugin
 - rosbag\_recorder\_plugin
 
-By default, the app will automatically close in 10 seconds.
+By default, the app will automatically close in 30 seconds.

--- a/test_app_manager/apps/test_app/test_app.py
+++ b/test_app_manager/apps/test_app/test_app.py
@@ -13,7 +13,7 @@ def main():
     rospy.loginfo('test_app started.')
     rospy.loginfo('param1: {}'.format(param1))
     rospy.loginfo('param2: {}'.format(param2))
-    time.sleep(10)
+    time.sleep(30)
     rospy.loginfo('test_app stopped.')
     sys.exit(0)
 


### PR DESCRIPTION
Depends on https://github.com/knorth55/app_manager_utils/pull/14

In my environment, test.avi is not saved with `test_app`.
After I set `time.sleep(30)`, test.avi is saved.
(The first time I run gazebo it seems to take a long time )

The sleep time depends on CPU power, but I think 30s is enough.