### PR TITLE
Add error message to prompt installing mailutils

### DIFF
--- a/app_notifier/src/app_notifier/mail_notifier_plugin.py
+++ b/app_notifier/src/app_notifier/mail_notifier_plugin.py
@@ -49,6 +49,7 @@ class MailNotifierPlugin(AppManagerPlugin):
             rospy.logerr(
                 'Failed to send e-mail:  {} -> {}'.format(
                     sender_address, receiver_address))
+            rospy.logerr("You may need to do '$ sudo apt install mailutils'")
         else:
             rospy.loginfo(
                 'Succeeded to send e-mail: {} -> {}'.format(


### PR DESCRIPTION
I add `rospy.logerr("You may need to do '$ sudo apt install mailutils'")` when sending email is failed.