### PR TITLE
Add use_timestamp_title usage to README.md

### DIFF
--- a/app_notifier/README.md
+++ b/app_notifier/README.md
@@ -26,6 +26,7 @@ plugins:
     type: app_notifier/mail_notifier_plugin
     plugin_args:
       mail_title: Test app
+      use_timestamp_title: true
       sender_address: hoge
       receiver_address: hoge
 ```


### PR DESCRIPTION
I got the following error when I did not specify `use_timestamp_title`:
```
[ERROR] [1627974196.829045]: handle stop app: internal error 'use_timestamp_title' 
```