### PR TITLE
Add error message to upgrade schedule module

### DIFF
--- a/app_scheduler/src/app_scheduler/app_scheduler.py
+++ b/app_scheduler/src/app_scheduler/app_scheduler.py
@@ -45,10 +45,20 @@ class AppScheduler(object):
     def _register_app(self, app):
         app_schedule = app['app_schedule']
         start_job = self._create_start_job(app['name'], app['app_name'])  # NOQA
-        eval('schedule.{}.do(start_job)'.format(app_schedule['start']))
+        try:
+            eval('schedule.{}.do(start_job)'.format(app_schedule['start']))
+        except (AssertionError, ValueError) as e:
+            rospy.logerr(e)
+            rospy.logerr('Cannot register start app')
+            rospy.logerr('Please upgrade schedule module. $ pip install schedule==0.6.0 --user')  # NOQA
         if 'stop' in app_schedule:
             stop_job = self._create_stop_job(app['name'], app['app_name'])  # NOQA
-            eval('schedule.{}.do(stop_job)'.format(app_schedule['stop']))
+            try:
+                eval('schedule.{}.do(stop_job)'.format(app_schedule['stop']))
+            except ValueError as e:
+                rospy.logerr(e)
+                rospy.logerr('Cannot register stop app')
+                rospy.logerr('Please upgrade schedule module. $ pip install schedule==0.6.0 --user')  # NOQA
 
     def _create_start_job(self, name, app_name):
         def start_job():
@@ -87,7 +97,12 @@ class AppScheduler(object):
                 self.running_jobs[name]['running'] = False
 
     def _timer_cb(self, event):
-        schedule.run_pending()
+        try:
+            schedule.run_pending()
+        except TypeError as e:
+            rospy.logerr(e)
+            rospy.logerr('Cannot run pending app')
+            rospy.logerr('Please upgrade schedule module. $ pip install schedule==0.6.0 --user')  # NOQA
 
     def _update_timer_cb(self, event):
         self._update_running_app_names()


### PR DESCRIPTION
With Python2.7 default schedule module (`schedule == 0.3.2`) , I got following error.
After `pip install schedule==0.6.0 --user`, the program works.

It seems that recent update solves the problem
https://github.com/dbader/schedule/issues/130

If this PR is not the best way to solve this error, please let me know.

```bash
$ roslaunch app_scheduler sample_app_scheduler.launch 
...
Traceback (most recent call last):                                                                                                                                                                                                                                                                                                                                                                                                                                         
  File "/home/leus/catkin_ws/src/knorth55/app_manager_utils/app_scheduler/scripts/app_scheduler", line 14, in <module>                                                                                                                                                                                                                                                                                                                                                     
    scheduler = AppScheduler(robot_name, yaml_path, duration, update_duration)                                                                                                                                                                                                                                                                                                                                                                                             
  File "/home/leus/catkin_ws/src/knorth55/app_manager_utils/app_scheduler/src/app_scheduler/app_scheduler.py", line 32, in __init__                                                                                                                                                                                                                                                                                                                                        
    self._register_apps()                                                                                                                                                                                                                                                                                                                                                                                                                                                  
  File "/home/leus/catkin_ws/src/knorth55/app_manager_utils/app_scheduler/src/app_scheduler/app_scheduler.py", line 43, in _register_apps                                                                                                                                                                                                                                                                                                                                  
    self._register_app(app)                                                                                                                                                                                                                                                                                                                                                                                                                                                
  File "/home/leus/catkin_ws/src/knorth55/app_manager_utils/app_scheduler/src/app_scheduler/app_scheduler.py", line 48, in _register_app                                                                                                                                                                                                                                                                                                                                   
    eval('schedule.{}.do(start_job)'.format(app_schedule['start']))                                                                                                                                                                                                                                                                                                                                                                                                        
  File "<string>", line 1, in <module>                                                                                                                                                                                                                                                                                                                                                                                                                                     
  File "/usr/lib/python2.7/dist-packages/schedule/__init__.py", line 255, in at                                                                                                                                                                                                                                                                                                                                                                                            
    assert self.unit in ('days', 'hours') or self.start_day                                                                                                                                                                                                                                                                                                                                                                                                                
AssertionError                                                                     
```

<details>
  <summary>All log</summary>
  
  ```bash
$ roslaunch app_scheduler sample_app_scheduler.launch
... logging to /home/leus/.ros/log/1eefc0ca-f74a-11eb-8d70-3868938abb41/roslaunch-leus-ThinkPad-P1-Gen-3-15171.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://192.168.1.15:41479/

SUMMARY
========

PARAMETERS
 * /app_manager/interface_master: http://localhost:...
 * /app_scheduler/duration: 1
 * /app_scheduler/update_duration: 60
 * /app_scheduler/yaml_path: /home/leus/catkin...
 * /rosdistro: melodic
 * /rosversion: 1.14.10

NODES
  /
    app_manager (app_manager/app_manager)
    app_scheduler (app_scheduler/app_scheduler)
    appmaster (app_manager/appmaster)

auto-starting new master
process[master]: started with pid [15181]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 1eefc0ca-f74a-11eb-8d70-3868938abb41
process[rosout-1]: started with pid [15192]
started core service [/rosout]
process[appmaster-2]: started with pid [15199]
process[app_manager-3]: started with pid [15200]
process[app_scheduler-4]: started with pid [15201]
[INFO] [1628318329.589979]: register app schedule => name: sample0, app_name: app_scheduler/sample0
Traceback (most recent call last):
  File "/home/leus/catkin_ws/src/knorth55/app_manager_utils/app_scheduler/scripts/app_scheduler", line 14, in <module>
    scheduler = AppScheduler(robot_name, yaml_path, duration, update_duration)
  File "/home/leus/catkin_ws/src/knorth55/app_manager_utils/app_scheduler/src/app_scheduler/app_scheduler.py", line 32, in __init__
    self._register_apps()
  File "/home/leus/catkin_ws/src/knorth55/app_manager_utils/app_scheduler/src/app_scheduler/app_scheduler.py", line 43, in _register_apps
    self._register_app(app)
  File "/home/leus/catkin_ws/src/knorth55/app_manager_utils/app_scheduler/src/app_scheduler/app_scheduler.py", line 48, in _register_app
    eval('schedule.{}.do(start_job)'.format(app_schedule['start']))
  File "<string>", line 1, in <module>
  File "/usr/lib/python2.7/dist-packages/schedule/__init__.py", line 255, in at
    assert self.unit in ('days', 'hours') or self.start_day
AssertionError                                                                                                                                                                                                                                                                                                                                                                                                                                                             
[app_scheduler-4] process has died [pid 15201, exit code 1, cmd /home/leus/catkin_ws/src/knorth55/app_manager_utils/app_scheduler/scripts/app_scheduler __name:=app_scheduler __log:=/home/leus/.ros/log/1eefc0ca-f74a-11eb-8d70-3868938abb41/app_scheduler-4.log].                                                                                                                                                                                                        
log file: /home/leus/.ros/log/1eefc0ca-f74a-11eb-8d70-3868938abb41/app_scheduler-4*.log                                                                                                                                                                                                                                                                                                                                                                                    
[INFO] [1628318330.625515]: Loading from plugin definitions                                                                                                                                                                                                                                                                                                                                                                                                                
[INFO] [1628318330.632573]: The param '/robot/type' is undefined. Using apps for any platforms                                                                                                                                                                                                                                                                                                                                                                             
[INFO] [1628318330.634444]: Starting app manager for robot                                                                                                                                                                                                                                                                                                                                                                                                                 
[INFO] [1628318330.638374]: Waiting for foreign master [http://localhost:11313] to come up...                                                                                                                                                                                                                                                                                                                                                                              
[INFO] [1628318330.639812]: Foreign master is available                                                                                                                                                                                                                                                                                                                                                                                                                    
[INFO] [1628318330.662734]: Registering (/robot/app_list,http://192.168.1.15:34483/) on master http://localhost:11313                                                                                                                                                                                                                                                                                                                                                      
[INFO] [1628318330.664965]: Registering (/robot/application/app_status,http://192.168.1.15:34483/) on master http://localhost:11313                                                                                                                                                                                                                                                                                                                                        
[INFO] [1628318330.667327]: Registering service (/robot/list_apps,rosrpc://192.168.1.15:41559) on master http://localhost:11313                                                                                                                                                                                                                                                                                                                                            
[INFO] [1628318330.670791]: Registering service (/robot/start_app,rosrpc://192.168.1.15:41559) on master http://localhost:11313                                                                                                                                                                                                                                                                                                                                            
[INFO] [1628318330.673908]: Registering service (/robot/stop_app,rosrpc://192.168.1.15:41559) on master http://localhost:11313                                                                                                                                                                                                                                                                                                                                             
[INFO] [1628318331.275705]: 4 apps found in /home/leus/catkin_ws/src/knorth55/app_manager_utils/app_scheduler/apps/apps.installed                                                                                                                                                                                                                                                                                                                                          
[INFO] [1628318331.583782]: 1 apps found in /home/leus/ros/melodic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/apps/robot_apps.installed      
  ```
</details>

```bash
$ pip show schedule
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
Name: schedule
Version: 0.3.2
Summary: Job scheduling for humans.
Home-page: https://github.com/dbader/schedule
Author: Daniel Bader
Author-email: mail@dbader.org
License: The MIT License (MIT)
Location: /usr/lib/python2.7/dist-packages
Requires:
Required-by:
```
