### PR TITLE
Add rostopic_publisher_plugin

### DIFF
--- a/app_manager_utils/package.xml
+++ b/app_manager_utils/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>app_notifier</exec_depend>
+  <exec_depend>app_publisher</exec_depend>
   <exec_depend>app_recorder</exec_depend>
   <exec_depend>app_scheduler</exec_depend>
   <exec_depend>app_uploader</exec_depend>

--- a/app_publisher/CMakeLists.txt
+++ b/app_publisher/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(app_publisher)
+
+find_package(catkin REQUIRED)
+
+catkin_python_setup()
+
+catkin_package()
+
+include_directories()

--- a/app_publisher/README.md
+++ b/app_publisher/README.md
@@ -1,0 +1,41 @@
+# app_publisher
+
+ROS topic publisher plugin for `app_manager`
+
+## `app_manager` plugins
+
+### `app_notifier/rostopic_publisher_plugin`: ROS topic publisher plugin
+
+This plugin publishes ROS topic at the beginning or end of the app.
+
+#### `plugin_args`: Plugin arguments
+
+- `start_topics`: topic which is published at the beginning of app
+  - `name`: name of the topic
+    `pkg`: package name of the message
+    `type`: type of the message
+- `stop_topics`: topic which is published at the end of app
+  - `name`: name of the topic
+    `pkg`: package name of the message
+    `type`: type of the message
+
+#### `launch_args`: Plugin launch arguments
+
+`None`
+
+#### Sample plugin description
+
+```yaml
+plugin_args:
+  start_topics:
+    - name: /test_bool1
+      pkg: std_msgs
+      type: Bool
+    - name: /test_bool2
+      pkg: std_msgs
+      type: Bool
+  stop_topics:
+    - name: /test_cancel
+      pkg: actionlib_msgs
+      type: GoalID
+```

--- a/app_publisher/app_publisher_plugin.yaml
+++ b/app_publisher/app_publisher_plugin.yaml
@@ -1,0 +1,3 @@
+- name: app_publisher/rostopic_publisher_plugin
+  launch: null
+  module: app_publisher.rostopic_publisher_plugin.RostopicPublisherPlugin

--- a/app_publisher/package.xml
+++ b/app_publisher/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>app_publisher</name>
+  <version>0.0.0</version>
+  <description>The app_publisher package</description>
+  <maintainer email="shingogo.5511@gmail.com">Shingo Kitagawa</maintainer>
+  <author email="708yamaguchi@gmail.com">Naoya Yamaguchi</author>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
+
+  <exec_depend>app_manager</exec_depend>
+
+  <export>
+    <app_manager plugin="${prefix}/app_publisher_plugin.yaml" />
+  </export>
+</package>

--- a/app_publisher/setup.py
+++ b/app_publisher/setup.py
@@ -1,0 +1,11 @@
+from catkin_pkg.python_setup import generate_distutils_setup
+from setuptools import find_packages
+from setuptools import setup
+
+
+d = generate_distutils_setup(
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+)
+
+setup(**d)

--- a/app_publisher/src/app_publisher/__init__.py
+++ b/app_publisher/src/app_publisher/__init__.py
@@ -1,0 +1,1 @@
+from app_publisher.rostopic_publisher_plugin import RostopicPublisherPlugin  # NOQA

--- a/app_publisher/src/app_publisher/rostopic_publisher_plugin.py
+++ b/app_publisher/src/app_publisher/rostopic_publisher_plugin.py
@@ -1,0 +1,31 @@
+import importlib
+
+from app_manager import AppManagerPlugin
+import rospy
+
+
+class RostopicPublisherPlugin(AppManagerPlugin):
+    def __init__(self):
+        super(RostopicPublisherPlugin, self).__init__()
+
+    def publish_topic(self, topic):
+        msg = getattr(
+            importlib.import_module(
+                '{}.msg'.format(topic['pkg'])), topic['type'])
+        pub = rospy.Publisher(topic['name'], msg, queue_size=1)
+        rospy.sleep(1)
+        pub.publish(msg())
+
+    def app_manager_start_plugin(self, app, ctx, plugin_args):
+        if 'start_topics' not in plugin_args:
+            return
+        topics = plugin_args['start_topics']
+        for topic in topics:
+            self.publish_topic(topic)
+
+    def app_manager_stop_plugin(self, app, ctx, plugin_args):
+        if 'stop_topics' not in plugin_args:
+            return
+        topics = plugin_args['stop_topics']
+        for topic in topics:
+            self.publish_topic(topic)


### PR DESCRIPTION
I add `rostopic_publisher_plugin`, which publishes ROS topic at the beginning or end of the app.

I think this plugin is useful when we stop app but other node still works.

For example, when we stop `go-to-kitchen` app, `move_base` sometimes still works.
With this app, we can send `/move_base/cancel` when we stop `go-to-kitchen` app.