### PR TITLE
Use topic field in rostopic_publisher_plugin.py

### DIFF
--- a/app_publisher/README.md
+++ b/app_publisher/README.md
@@ -18,6 +18,7 @@ This plugin publishes ROS topic at the beginning or end of the app.
   - `name`: name of the topic
   - `pkg`: package name of the message
   - `type`: type of the message
+  - `field`: content of the message field
 
 #### `launch_args`: Plugin launch arguments
 
@@ -28,12 +29,30 @@ This plugin publishes ROS topic at the beginning or end of the app.
 ```yaml
 plugin_args:
   start_topics:
-    - name: /test_bool1
+    - name: /test_bool
       pkg: std_msgs
       type: Bool
-    - name: /test_bool2
-      pkg: std_msgs
-      type: Bool
+    - name: /test_polygon_stamped
+      pkg: geometry_msgs
+      type: PolygonStamped
+      field:
+        header:
+          seq: 0
+          stamp:
+            secs: 1631124596
+            nsecs: 589318
+          frame_id: /test
+        polygon:
+          points:
+            - x: 1
+              y: 0
+              z: 0
+            - x: 0
+              y: 1
+              z: 0
+            - x: 0
+              y: 0
+              z: 1
   stop_topics:
     - name: /test_cancel
       pkg: actionlib_msgs

--- a/app_publisher/README.md
+++ b/app_publisher/README.md
@@ -27,34 +27,35 @@ This plugin publishes ROS topic at the beginning or end of the app.
 #### Sample plugin description
 
 ```yaml
-plugin_args:
-  start_topics:
-    - name: /test_bool
-      pkg: std_msgs
-      type: Bool
-    - name: /test_polygon_stamped
-      pkg: geometry_msgs
-      type: PolygonStamped
-      field:
-        header:
-          seq: 0
-          stamp:
-            secs: 1631124596
-            nsecs: 589318
-          frame_id: /test
-        polygon:
-          points:
-            - x: 1
-              y: 0
-              z: 0
-            - x: 0
-              y: 1
-              z: 0
-            - x: 0
-              y: 0
-              z: 1
-  stop_topics:
-    - name: /test_cancel
-      pkg: actionlib_msgs
-      type: GoalID
+plugins
+  - name: rostopic_publisher_plugin
+    type: app_publisher/rostopic_publisher_plugin
+    plugin_args:
+      start_topics:
+        - name: /test_bool
+          pkg: std_msgs
+          type: Bool
+        - name: /test_polygon_stamped
+          pkg: geometry_msgs
+          type: PolygonStamped
+          field:
+            header:
+              seq: 0
+              stamp: now
+              frame_id: test
+            polygon:
+              points:
+                - x: 1
+                  y: 0
+                  z: 0
+                - x: 0
+                  y: 1
+                  z: 0
+                - x: 0
+                  y: 0
+                  z: 1
+      stop_topics:
+        - name: /test_cancel
+          pkg: actionlib_msgs
+          type: GoalID
 ```

--- a/app_publisher/package.xml
+++ b/app_publisher/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>app_manager</exec_depend>
+  <exec_depend>rospy_message_converter</exec_depend>
 
   <export>
     <app_manager plugin="${prefix}/app_publisher_plugin.yaml" />

--- a/app_publisher/src/app_publisher/rostopic_publisher_plugin.py
+++ b/app_publisher/src/app_publisher/rostopic_publisher_plugin.py
@@ -2,6 +2,7 @@ import importlib
 
 from app_manager import AppManagerPlugin
 import rospy
+from rospy_message_converter import message_converter
 
 
 class RostopicPublisherPlugin(AppManagerPlugin):
@@ -14,7 +15,13 @@ class RostopicPublisherPlugin(AppManagerPlugin):
                 '{}.msg'.format(topic['pkg'])), topic['type'])
         pub = rospy.Publisher(topic['name'], msg, queue_size=1)
         rospy.sleep(1)
-        pub.publish(msg())
+        if 'field' in topic:
+            pub_msg = message_converter.convert_dictionary_to_ros_message(
+                '{}/{}'.format(topic['pkg'], topic['type']),
+                topic['field'])
+        else:
+            pub_msg = msg()
+        pub.publish(pub_msg)
 
     def app_manager_start_plugin(self, app, ctx, plugin_args):
         if 'start_topics' not in plugin_args:

--- a/test_app_manager/apps/test_app/test_app.app
+++ b/test_app_manager/apps/test_app/test_app.app
@@ -10,6 +10,35 @@ plugins:
     type: test_app_manager/test_stop_plugin
   - name: test_time_plugin
     type: test_app_manager/test_time_plugin
+  - name: test_rostopic_publisher_plugin
+    type: app_publisher/rostopic_publisher_plugin
+    plugin_args:
+      start_topics:
+        - name: /test_bool
+          pkg: std_msgs
+          type: Bool
+          field:
+            data: true
+      stop_topics:
+        - name: /test_polygon_stamped
+          pkg: geometry_msgs
+          type: PolygonStamped
+          field:
+            header:
+              seq: 0
+              stamp: now
+              frame_id: test
+            polygon:
+              points:
+                - x: 1
+                  y: 0
+                  z: 0
+                - x: 0
+                  y: 1
+                  z: 0
+                - x: 0
+                  y: 0
+                  z: 1
   - name: result_recorder_plugin
     type: app_recorder/result_recorder_plugin
     plugin_args:
@@ -35,6 +64,7 @@ plugin_order:
     - test_start_plugin
     - test_stop_plugin
     - test_time_plugin
+    - test_rostopic_publisher_plugin
     - result_recorder_plugin
     - video_recorder_plugin
     - rosbag_recorder_plugin
@@ -42,6 +72,7 @@ plugin_order:
     - test_start_plugin
     - test_stop_plugin
     - test_time_plugin
+    - test_rostopic_publisher_plugin
     - result_recorder_plugin
     - video_recorder_plugin
     - rosbag_recorder_plugin

--- a/test_app_manager/package.xml
+++ b/test_app_manager/package.xml
@@ -13,6 +13,7 @@
 
   <exec_depend>app_manager</exec_depend>
   <exec_depend>pr2_gazebo</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <export>
     <!-- <app_manager app_dir="${prefix}/apps"/> -->


### PR DESCRIPTION
I checked that `rostopic_publisher_plugin.py` can publish ROS topic with the field content.

However, I cannot install `rospy_message_converter` with `catkin_virtualenv`
I will fix this issue if I have time...