### PR TITLE
[app_notifier] Wait until the postfix queue is empty

### DIFF
--- a/app_notifier/src/app_notifier/mail_notifier_plugin.py
+++ b/app_notifier/src/app_notifier/mail_notifier_plugin.py
@@ -5,6 +5,7 @@ from app_manager import AppManagerPlugin
 import rospy
 
 from app_notifier.util import check_timestamp_before_start
+from app_notifier.util import count_postfix_queued_mail
 from app_notifier.util import get_notification_json_paths
 from app_notifier.util import load_notification_jsons
 from app_notifier.util import parse_context
@@ -71,10 +72,19 @@ class MailNotifierPlugin(AppManagerPlugin):
                         event['date'], event['message'], event['location'])
             mail_content += "\\n"
 
+        queued_mail_num = count_postfix_queued_mail()
         cmd = "LC_CTYPE=en_US.UTF-8 /bin/echo -e \"{}\"".format(mail_content)
         cmd += " | /usr/bin/mail -s \"{}\" -r {} {}".format(
             mail_title, sender_address, receiver_address)
         exit_code = subprocess.call(cmd, shell=True)
+
+        # Wait for mail to be added in postfix queue
+        while queued_mail_num == count_postfix_queued_mail():
+            rospy.sleep(0.1)
+        # Wait for mail to be send from queue
+        while queued_mail_num < count_postfix_queued_mail():
+            rospy.sleep(0.1)
+
         rospy.loginfo('Title: {}'.format(mail_title))
         if exit_code > 0:
             rospy.logerr(

--- a/app_notifier/src/app_notifier/mail_notifier_plugin.py
+++ b/app_notifier/src/app_notifier/mail_notifier_plugin.py
@@ -79,10 +79,15 @@ class MailNotifierPlugin(AppManagerPlugin):
         exit_code = subprocess.call(cmd, shell=True)
 
         # Wait for mail to be added in postfix queue
-        while queued_mail_num == count_postfix_queued_mail():
+        timeout = 10
+        start_time = rospy.Time.now()
+        while (queued_mail_num == count_postfix_queued_mail()
+               or (rospy.Time.now() - start_time).to_sec() > timeout):
             rospy.sleep(0.1)
         # Wait for mail to be send from queue
-        while queued_mail_num < count_postfix_queued_mail():
+        start_time = rospy.Time.now()
+        while (queued_mail_num < count_postfix_queued_mail()
+               or (rospy.Time.now() - start_time).to_sec() > timeout):
             rospy.sleep(0.1)
 
         rospy.loginfo('Title: {}'.format(mail_title))

--- a/app_notifier/src/app_notifier/util.py
+++ b/app_notifier/src/app_notifier/util.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import os
 import rospy
+import subprocess
 import sys
 
 from rostwitter.msg import TweetGoal
@@ -111,3 +112,9 @@ def parse_context(ctx):
     if 'upload_file_urls' in ctx:
         upload_file_urls = ctx['upload_file_urls']
     return exit_code, stopped, timeout, upload_successes, upload_file_urls
+
+
+def count_postfix_queued_mail():
+    postqueue = subprocess.check_output(['postqueue', '-j'])
+    queued_mail_num = postqueue.count('queue_name')
+    return queued_mail_num


### PR DESCRIPTION
When I use the following `stop_plugin_order`, the shutdown is executed before finishing sending mail.
```
  stop_plugin_order:
    - mail_notifier_plugin
    - shutdown_plugin
```

This is because `mail_notifier_plugin` finishes when the mail is put into the postfix queue (before actually sending the mail).

I this PR, `mail_notifier_plugin.py` wait for the mail to be sent from postfix queue.


FYI:
```
$ man postqueue

       -j     Produce a queue listing in JSON format, based on output from  the  showq(8)  daemon.
              The  result  is  a  stream  of  zero or more JSON objects, one per queue file.  Each
              object is followed by a newline character to support simple streaming  parsers.  See
              "JSON OBJECT FORMAT" below for details.

```
example of `$ postqueue -j`

```
{"queue_name": "active", "queue_id": "4C1DFD404DD", "arrival_time": 1642055079, "message_size": 90350, "sender": "leus@leus-ThinkPad-P1-Gen-3", "recipients": [{"address": "yamaguchi@jsk.imi.i.u-tokyo.ac.jp"}]}
```