### PR TITLE
[app_recorder] Add rosbag converter plugins

### DIFF
--- a/.ci.rosinstall
+++ b/.ci.rosinstall
@@ -2,10 +2,3 @@
     local-name: audio_video_recorder
     uri: https://github.com/knorth55/audio_video_recorder.git
     version: main
-# Use jsk-ros-pkg/jsk_common master branch after the following PR is merged.
-# Remove jsk_common after the following PR is released.
-# https://github.com/jsk-ros-pkg/jsk_common/pull/1738
-- git:
-    local-name: jsk_common
-    uri: https://github.com/iory/jsk_common.git
-    version: rosbag-tools

--- a/.ci.rosinstall
+++ b/.ci.rosinstall
@@ -2,3 +2,10 @@
     local-name: audio_video_recorder
     uri: https://github.com/knorth55/audio_video_recorder.git
     version: main
+# Use jsk-ros-pkg/jsk_common master branch after the following PR is merged.
+# Remove jsk_common after the following PR is released.
+# https://github.com/jsk-ros-pkg/jsk_common/pull/1738
+- git:
+    local-name: jsk_common
+    uri: https://github.com/iory/jsk_common.git
+    version: rosbag-tools

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,15 +14,23 @@ jobs:
           - ROS_DISTRO: kinetic
             ROS_REPO: testing
             UPSTREAM_WORKSPACE: '.ci.rosinstall'
+            # Remove jsk_rosbag_tools after it is registered as rosdep key
+            ROSDEP_SKIP_KEYS: 'jsk_rosbag_tools'
           - ROS_DISTRO: kinetic
             ROS_REPO: main
             UPSTREAM_WORKSPACE: '.ci.rosinstall'
+            # Remove jsk_rosbag_tools after it is registered as rosdep key
+            ROSDEP_SKIP_KEYS: 'jsk_rosbag_tools'
           - ROS_DISTRO: melodic
             ROS_REPO: testing
             UPSTREAM_WORKSPACE: '.ci.rosinstall'
+            # Remove jsk_rosbag_tools after it is registered as rosdep key
+            ROSDEP_SKIP_KEYS: 'jsk_rosbag_tools'
           - ROS_DISTRO: melodic
             ROS_REPO: main
             UPSTREAM_WORKSPACE: '.ci.rosinstall'
+            # Remove jsk_rosbag_tools after it is registered as rosdep key
+            ROSDEP_SKIP_KEYS: 'jsk_rosbag_tools'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/app_recorder/README.md
+++ b/app_recorder/README.md
@@ -212,3 +212,85 @@ plugins:
       result_path: /tmp
       result_title: test.yaml
 ```
+
+### `app_recorder/rosbag_audio_converter_plugin`: Rosbag audio converter plugin
+
+This plugin converts rosbag to audio file when app finishs.
+
+#### `plugin_args`: Plugin arguments
+
+- `rosbag_path`:
+  - rosbag file directory path
+- `rosbag_title`:
+  - rosbag file name
+- `audio_path`:
+  - Output audio file (.wav)
+- `audio_topic_name`:
+  - Input audio topic name
+- `audio_sample_rate`:
+  - Input audio sample rate
+- `audio_channels`:
+  - Input audio the number of channels
+
+#### `launch_args`: Plugin launch arguments
+
+`None`
+
+#### Sample plugin description
+
+```yaml
+plugins:
+  - name: respeaker_audio_converter_plugin
+    type: app_recorder/rosbag_audio_converter_plugin
+    plugin_args:
+      rosbag_path: /tmp
+      rosbag_title: go_to_kitchen_rosbag.bag
+      audio_path: /tmp/go_to_kitchen_audio.wav
+      audio_topic_name: /audio
+      audio_sample_rate: 16000
+      audio_channels: 1
+```
+
+### `app_recorder/rosbag_video_converter_plugin`: Rosbag video converter plugin
+
+This plugin converts rosbag to video file when app finishs. If `audio_topic_name` is given, video with audio is generated.
+
+#### `plugin_args`: Plugin arguments
+
+- `rosbag_path`:
+  - rosbag file directory path
+- `rosbag_title`:
+  - rosbag file name
+- `video_path`:
+  - Output video file (.mp4)
+- `image_topic_name`:
+  - Input image topic name
+- `image_fps`:
+  - Input image frame rate
+- `audio_topic_name`:
+  - Input audio topic name
+- `audio_sample_rate`:
+  - Input audio sample rate
+- `audio_channels`:
+  - Input audio the number of channels
+
+#### `launch_args`: Plugin launch arguments
+
+`None`
+
+#### Sample plugin description
+
+```yaml
+plugins:
+  - name: head_camera_converter_plugin
+    type: app_recorder/rosbag_video_converter_plugin
+    plugin_args:
+      rosbag_path: /tmp
+      rosbag_title: go_to_kitchen_rosbag.bag
+      video_path: /tmp/go_to_kitchen_head_camera.mp4
+      image_topic_name: /head_camera/rgb/throttled/image_rect_color/compressed
+      image_fps: 5
+      audio_topic_name: /audio
+      audio_sample_rate: 16000
+      audio_channels: 1
+```

--- a/app_recorder/app_recorder_plugin.yaml
+++ b/app_recorder/app_recorder_plugin.yaml
@@ -13,3 +13,9 @@
 - name: app_recorder/result_recorder_plugin
   launch: null
   module: app_recorder.result_recorder_plugin.ResultRecorderPlugin
+- name: app_recorder/rosbag_audio_converter_plugin
+  launch: null
+  module: app_recorder.rosbag_audio_converter_plugin.RosbagAudioConverterPlugin
+- name: app_recorder/rosbag_video_converter_plugin
+  launch: null
+  module: app_recorder.rosbag_video_converter_plugin.RosbagVideoConverterPlugin

--- a/app_recorder/package.xml
+++ b/app_recorder/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>audio_video_recorder</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>image_view</exec_depend>
+  <exec_depend>jsk_rosbag_tools</exec_depend>
 
   <export>
     <app_manager plugin="${prefix}/app_recorder_plugin.yaml" />

--- a/app_recorder/src/app_recorder/__init__.py
+++ b/app_recorder/src/app_recorder/__init__.py
@@ -3,3 +3,5 @@ from app_recorder.audio_video_recorder_plugin import AudioVideoRecorderPlugin  #
 from app_recorder.result_recorder_plugin import ResultRecorderPlugin  # NOQA
 from app_recorder.rosbag_recorder_plugin import RosbagRecorderPlugin  # NOQA
 from app_recorder.video_recorder_plugin import VideoRecorderPlugin  # NOQA
+from app_recorder.rosbag_audio_converter_plugin import RosbagAudioConverterPlugin  # NOQA
+from app_recorder.rosbag_video_converter_plugin import RosbagVideoConverterPlugin  # NOQA

--- a/app_recorder/src/app_recorder/rosbag_audio_converter_plugin.py
+++ b/app_recorder/src/app_recorder/rosbag_audio_converter_plugin.py
@@ -1,5 +1,6 @@
 from jsk_rosbag_tools.bag_to_audio import bag_to_audio
 import os
+import rospy
 
 from app_manager import AppManagerPlugin
 
@@ -21,5 +22,5 @@ class RosbagAudioConverterPlugin(AppManagerPlugin):
             bag_to_audio(rosbag_file_path, **kwargs)
         except ValueError as e:
             # topic is not included in bagfile
-            print('{}'.format(e))
+            rospy.logerr('{}'.format(e))
         return ctx

--- a/app_recorder/src/app_recorder/rosbag_audio_converter_plugin.py
+++ b/app_recorder/src/app_recorder/rosbag_audio_converter_plugin.py
@@ -1,0 +1,25 @@
+from jsk_rosbag_tools.bag_to_audio import bag_to_audio
+import os
+
+from app_manager import AppManagerPlugin
+
+
+class RosbagAudioConverterPlugin(AppManagerPlugin):
+    def __init__(self):
+        super(RosbagAudioConverterPlugin, self).__init__()
+
+    @classmethod
+    def app_manager_stop_plugin(cls, app, ctx, plugin_args):
+        rosbag_file_path = os.path.join(
+            str(plugin_args['rosbag_path']),
+            str(plugin_args['rosbag_title']))
+        kwargs = {'wav_outpath': str(plugin_args['audio_path']),
+                  'topic_name': str(plugin_args['audio_topic_name']),
+                  'samplerate': int(plugin_args['audio_sample_rate']),
+                  'channels': int(plugin_args['audio_channels'])}
+        try:
+            bag_to_audio(rosbag_file_path, **kwargs)
+        except ValueError as e:
+            # topic is not included in bagfile
+            print('{}'.format(e))
+        return ctx

--- a/app_recorder/src/app_recorder/rosbag_audio_converter_plugin.py
+++ b/app_recorder/src/app_recorder/rosbag_audio_converter_plugin.py
@@ -1,6 +1,12 @@
-from jsk_rosbag_tools.bag_to_audio import bag_to_audio
-import os
 import rospy
+try:
+    from jsk_rosbag_tools.bag_to_audio import bag_to_audio
+except ImportError as e:
+    rospy.logerr('{}'.format(e))
+    rospy.logerr('Skip using rosbag_audio_converter_plugin')
+    import sys
+    sys.exit(0)
+import os
 
 from app_manager import AppManagerPlugin
 

--- a/app_recorder/src/app_recorder/rosbag_video_converter_plugin.py
+++ b/app_recorder/src/app_recorder/rosbag_video_converter_plugin.py
@@ -1,0 +1,30 @@
+from jsk_rosbag_tools.bag_to_video import bag_to_video
+import os
+
+from app_manager import AppManagerPlugin
+
+
+class RosbagVideoConverterPlugin(AppManagerPlugin):
+    def __init__(self):
+        super(RosbagVideoConverterPlugin, self).__init__()
+
+    @classmethod
+    def app_manager_stop_plugin(cls, app, ctx, plugin_args):
+        rosbag_file_path = os.path.join(
+            str(plugin_args['rosbag_path']),
+            str(plugin_args['rosbag_title']))
+        kwargs = {'output_filepath': str(plugin_args['video_path']),
+                  'image_topic': str(plugin_args['image_topic_name']),
+                  'fps': int(plugin_args['image_fps'])}
+        # If audio_topic_name is given, video with audio is converted
+        if 'audio_topic_name' in plugin_args:
+            audio_kwargs = {'audio_topic': str(plugin_args['audio_topic_name']),
+                            'samplerate': int(plugin_args['audio_sample_rate']),
+                            'channels': int(plugin_args['audio_channels'])}
+            kwargs.update(audio_kwargs)
+        try:
+            bag_to_video(rosbag_file_path, **kwargs)
+        except ValueError as e:
+            # topic is not included in bagfile
+            print(e)
+        return ctx

--- a/app_recorder/src/app_recorder/rosbag_video_converter_plugin.py
+++ b/app_recorder/src/app_recorder/rosbag_video_converter_plugin.py
@@ -1,6 +1,12 @@
-from jsk_rosbag_tools.bag_to_video import bag_to_video
-import os
 import rospy
+try:
+    from jsk_rosbag_tools.bag_to_video import bag_to_video
+except ImportError as e:
+    rospy.logerr('{}'.format(e))
+    rospy.logerr('Skip using rosbag_video_converter_plugin')
+    import sys
+    sys.exit(0)
+import os
 
 from app_manager import AppManagerPlugin
 

--- a/app_recorder/src/app_recorder/rosbag_video_converter_plugin.py
+++ b/app_recorder/src/app_recorder/rosbag_video_converter_plugin.py
@@ -19,9 +19,10 @@ class RosbagVideoConverterPlugin(AppManagerPlugin):
                   'fps': int(plugin_args['image_fps'])}
         # If audio_topic_name is given, video with audio is converted
         if 'audio_topic_name' in plugin_args:
-            audio_kwargs = {'audio_topic': str(plugin_args['audio_topic_name']),
-                            'samplerate': int(plugin_args['audio_sample_rate']),
-                            'channels': int(plugin_args['audio_channels'])}
+            audio_kwargs = {
+                'audio_topic': str(plugin_args['audio_topic_name']),
+                'samplerate': int(plugin_args['audio_sample_rate']),
+                'channels': int(plugin_args['audio_channels'])}
             kwargs.update(audio_kwargs)
         try:
             bag_to_video(rosbag_file_path, **kwargs)

--- a/app_recorder/src/app_recorder/rosbag_video_converter_plugin.py
+++ b/app_recorder/src/app_recorder/rosbag_video_converter_plugin.py
@@ -1,5 +1,6 @@
 from jsk_rosbag_tools.bag_to_video import bag_to_video
 import os
+import rospy
 
 from app_manager import AppManagerPlugin
 
@@ -26,5 +27,5 @@ class RosbagVideoConverterPlugin(AppManagerPlugin):
             bag_to_video(rosbag_file_path, **kwargs)
         except ValueError as e:
             # topic is not included in bagfile
-            print(e)
+            rospy.logerr('{}'.format(e))
         return ctx

--- a/test_app_manager/apps/test_app/test_app.app
+++ b/test_app_manager/apps/test_app/test_app.app
@@ -62,6 +62,15 @@ plugins:
       rosbag_topic_names:
         - /tf
         - /joint_states
+        - /wide_stereo/right/image_rect_color
+  - name: rosbag_video_converter_plugin
+    type: app_recorder/rosbag_video_converter_plugin
+    plugin_args:
+      rosbag_path: /tmp
+      rosbag_title: test.bag
+      image_topic_name: /wide_stereo/right/image_rect_color
+      image_fps: 20
+      video_path: /tmp/test_converted.mp4
 plugin_order:
   start_plugin_order:
     - test_start_plugin
@@ -71,6 +80,7 @@ plugin_order:
     - result_recorder_plugin
     - video_recorder_plugin
     - rosbag_recorder_plugin
+    - rosbag_video_converter_plugin
   stop_plugin_order:
     - test_start_plugin
     - test_stop_plugin
@@ -79,3 +89,4 @@ plugin_order:
     - result_recorder_plugin
     - video_recorder_plugin
     - rosbag_recorder_plugin
+    - rosbag_video_converter_plugin


### PR DESCRIPTION
Depends on https://github.com/jsk-ros-pkg/jsk_common/pull/1738
Tests will pass after the above PR is released.

I add plugin to convert rosbag into audio or video file.

With this script, we can generate video files from rosbag after the app.
I this case, we do not have to generate the video files while the app is running.

This can reduce CPU usage during app compared to audio_video_recorder.