### PR TITLE
[app_notifier] Add option to display start time in mail title

### DIFF
--- a/app_notifier/src/app_notifier/mail_notifier_plugin.py
+++ b/app_notifier/src/app_notifier/mail_notifier_plugin.py
@@ -14,6 +14,7 @@ from app_notifier.util import parse_context
 class MailNotifierPlugin(AppManagerPlugin):
     def __init__(self):
         super(MailNotifierPlugin, self).__init__()
+        self.use_app_start_time = False
 
     def app_manager_start_plugin(self, app, ctx, plugin_args):
         self.start_time = rospy.Time.now()

--- a/app_notifier/src/app_notifier/mail_notifier_plugin.py
+++ b/app_notifier/src/app_notifier/mail_notifier_plugin.py
@@ -17,6 +17,16 @@ class MailNotifierPlugin(AppManagerPlugin):
 
     def app_manager_start_plugin(self, app, ctx, plugin_args):
         self.start_time = rospy.Time.now()
+        # Set mail title first for extensibility
+        self.use_app_start_time = False
+        if 'use_app_start_time' in plugin_args:
+            self.use_app_start_time = plugin_args['use_app_start_time']
+        if self.use_app_start_time:
+            mail_title = plugin_args['mail_title']
+            timestamp = '{0:%Y/%m/%d (%H:%M:%S)}'.format(
+                datetime.datetime.fromtimestamp(self.start_time.to_sec()))
+            mail_title += ': {}'.format(timestamp)
+            rospy.set_param('~mail_title', mail_title)
 
     def app_manager_stop_plugin(self, app, ctx, plugin_args):
         mail_title = plugin_args['mail_title']
@@ -27,8 +37,12 @@ class MailNotifierPlugin(AppManagerPlugin):
             use_timestamp_title = plugin_args['use_timestamp_title']
 
         if use_timestamp_title:
-            timestamp = '{0:%Y/%m/%d (%H:%M:%S)}'.format(
-                datetime.datetime.now())
+            if self.use_app_start_time:
+                timestamp = '{0:%Y/%m/%d (%H:%M:%S)}'.format(
+                    datetime.datetime.fromtimestamp(self.start_time.to_sec()))
+            else:
+                timestamp = '{0:%Y/%m/%d (%H:%M:%S)}'.format(
+                    datetime.datetime.now())
             mail_title += ': {}'.format(timestamp)
 
         exit_code, stopped, timeout,\
@@ -109,4 +123,8 @@ class MailNotifierPlugin(AppManagerPlugin):
                 'Succeeded to send e-mail: {} -> {}'.format(
                     sender_address, receiver_address))
         ctx['mail_notifier_exit_code'] = exit_code
+        # delete ~mail_title rosparam for next
+        # It is assumed that this is the last one sent in a series of emails.
+        if rospy.has_param('~mail_title'):
+            rospy.delete_param('~mail_title')
         return ctx

--- a/app_notifier/src/app_notifier/mail_notifier_plugin.py
+++ b/app_notifier/src/app_notifier/mail_notifier_plugin.py
@@ -27,7 +27,7 @@ class MailNotifierPlugin(AppManagerPlugin):
             timestamp = '{0:%Y/%m/%d (%H:%M:%S)}'.format(
                 datetime.datetime.fromtimestamp(self.start_time.to_sec()))
             mail_title += ': {}'.format(timestamp)
-            rospy.set_param('~mail_title', mail_title)
+            rospy.set_param('/email_topic/mail_title', mail_title)
 
     def app_manager_stop_plugin(self, app, ctx, plugin_args):
         mail_title = plugin_args['mail_title']

--- a/app_notifier/src/app_notifier/mail_notifier_plugin.py
+++ b/app_notifier/src/app_notifier/mail_notifier_plugin.py
@@ -17,8 +17,8 @@ class MailNotifierPlugin(AppManagerPlugin):
 
     def app_manager_start_plugin(self, app, ctx, plugin_args):
         self.start_time = rospy.Time.now()
-        # Set mail title first for extensibility
-        self.use_app_start_time = False
+        # Set mail title first if use_app_start_time is true.
+        # This can combine many emails into a single email thread.
         if 'use_app_start_time' in plugin_args:
             self.use_app_start_time = plugin_args['use_app_start_time']
         if self.use_app_start_time:

--- a/app_notifier/src/app_notifier/mail_notifier_plugin.py
+++ b/app_notifier/src/app_notifier/mail_notifier_plugin.py
@@ -39,11 +39,11 @@ class MailNotifierPlugin(AppManagerPlugin):
 
         if use_timestamp_title:
             if self.use_app_start_time:
-                timestamp = '{0:%Y/%m/%d (%H:%M:%S)}'.format(
-                    datetime.datetime.fromtimestamp(self.start_time.to_sec()))
+                unix_time = self.start_time.to_sec()
             else:
-                timestamp = '{0:%Y/%m/%d (%H:%M:%S)}'.format(
-                    datetime.datetime.now())
+                unix_time = datetime.datetime.now()
+            timestamp = '{0:%Y/%m/%d (%H:%M:%S)}'.format(
+                datetime.datetime.fromtimestamp(unix_time))
             mail_title += ': {}'.format(timestamp)
 
         exit_code, stopped, timeout,\


### PR DESCRIPTION
This change is related to the creation of smach_to_mail.py in jsk-ros-pkg. 
Currently two emails are sent in kitchen patrol demo(using both app notifier and smach_to_mail.py), but these can be combined into a single email thread by using the same title.

To set the same mail title, the mail title is set in rosparam when mail_notifier is started.

cc: @708yamaguchi